### PR TITLE
updated unique router link to pastpatients, and tried to do that for …

### DIFF
--- a/src/components/PastPatients.vue
+++ b/src/components/PastPatients.vue
@@ -2,9 +2,8 @@
     <div class = "my_patients">
             <a v-for= "patient in AllMyPatients" v-bind:key="patient.index">
                 <div id="patient_box">
-                    <!-- router link not correct, not sure what to put yet -->
-                    <h3>{{patient.data().name}}</h3>
-                    <!-- <h3><router-link to="/patientProfile" id="patientName">{{patient.data().name}}</router-link></h3> -->
+                    <!-- <h3>{{patient.data().name}}</h3> -->
+                    <h3><router-link :to="{ name: 'PatientProfile', params: { id: patient.id }}">{{patient.data().name}}</router-link></h3>
                 </div>
             </a>
     </div>

--- a/src/views/Patient/PatientLogin.vue
+++ b/src/views/Patient/PatientLogin.vue
@@ -25,9 +25,13 @@ export default {
         if (!ui){
             ui = new firebaseui.auth.AuthUI(firebase.auth());
         }
-
+        //tried to add this but the login wont really appear?
+        // var user = firebaseui.auth.AuthUI.getInstance().getCurrentUser();
+        // console.log(user)
         var uiConfig = {
-            signInSuccessUrl: "/patientProfile",
+            
+            // signInSuccessUrl:this.$router.push({ name: 'PatientProfile', params: { id: this.id } }),
+            signInSuccessUrl: "/patientProfile/:id", //this part abit weird but not sure how to change it to the top
             signInOptions: [
                 firebase.auth.EmailAuthProvider.PROVIDER_ID,
             ]


### PR DESCRIPTION
…patientlogin

For patientlogin, right now when login will show /PatientProfile/:id VS when press My Profile will show the correct /PatientProfile/patient'semail. Not so sure how to alter patient's login to make the path name include the email using firebaseui